### PR TITLE
Run client with default ImGui overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-# GUI 모드
-python main.py <server-host> --gui
-
-# CLI 모드
 python main.py <server-host>
 ```
+
+기본적으로 ImGui 기반의 오버레이 GUI와 오디오 클라이언트가 동시에 실행됩니다.
+`Insert` 키로 GUI 표시를 토글할 수 있습니다.

--- a/main.py
+++ b/main.py
@@ -12,14 +12,21 @@ from livelingo.client import run_client
 
 def main() -> None:
     parser = build_parser()
-    parser.add_argument("--gui", action="store_true", help="run ImGui interface instead of CLI")
     args = parser.parse_args()
-    if args.gui:
-        from livelingo.ui import run_ui  # Lazy import to avoid OpenGL requirement for CLI
 
-        run_ui()
-    else:
-        run_client(args.host, args.port, args.sr, args.block, args.srt)
+    # Run the audio client in a background thread
+    import threading
+    client_thread = threading.Thread(
+        target=run_client,
+        args=(args.host, args.port, args.sr, args.block, args.srt),
+        daemon=True,
+    )
+    client_thread.start()
+
+    # Launch the ImGui overlay UI in the main thread
+    from livelingo.ui import run_ui  # Lazy import to avoid OpenGL requirement for CLI
+
+    run_ui()
 
 
 if __name__ == "__main__":

--- a/src/livelingo/ui.py
+++ b/src/livelingo/ui.py
@@ -1,43 +1,65 @@
 import imgui
 from imgui.integrations.glfw import GlfwRenderer
 import glfw
-import OpenGL.GL as gl  # 선택: 화면 클리어 용
+import OpenGL.GL as gl  # OpenGL bindings for rendering
 
 def run_ui() -> None:
+    """Run the ImGui overlay user interface."""
     if not glfw.init():
         raise RuntimeError("Could not initialize GLFW")
 
-    window = glfw.create_window(800, 600, "LiveLingo", None, None)
+    # Configure window for transparent overlay that stays on top
+    glfw.window_hint(glfw.TRANSPARENT_FRAMEBUFFER, glfw.TRUE)
+    glfw.window_hint(glfw.DECORATED, glfw.FALSE)
+    glfw.window_hint(glfw.FLOATING, glfw.TRUE)
+    glfw.window_hint(glfw.MOUSE_PASSTHROUGH, glfw.TRUE)
+
+    monitor = glfw.get_primary_monitor()
+    mode = glfw.get_video_mode(monitor)
+    width, height = mode.size.width, mode.size.height
+    window = glfw.create_window(width, height, "LiveLingo", None, None)
     if window is None:
         glfw.terminate()
         raise RuntimeError("Failed to create GLFW window")
 
+    glfw.set_window_pos(window, 0, 0)
     glfw.make_context_current(window)
 
-    # ★ ImGui 컨텍스트 생성 (중요)
+    # ImGui context setup
     imgui.create_context()
-
     impl = GlfwRenderer(window)
+
+    # Enable alpha blending for transparency
+    gl.glEnable(gl.GL_BLEND)
+    gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+
+    show = True
+    prev_insert = glfw.RELEASE
 
     try:
         while not glfw.window_should_close(window):
             glfw.poll_events()
             impl.process_inputs()
 
-            imgui.new_frame()
+            # Toggle UI visibility with the Insert key
+            state = glfw.get_key(window, glfw.KEY_INSERT)
+            if state == glfw.PRESS and prev_insert == glfw.RELEASE:
+                show = not show
+            prev_insert = state
 
-            imgui.begin("LiveLingo")
-            imgui.text("ImGui UI placeholder")
-            imgui.end()
-
-            # 선택: 화면 클리어
-            gl.glClearColor(0.1, 0.1, 0.1, 1.0)
+            gl.glClearColor(0.0, 0.0, 0.0, 0.0)
             gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
+            imgui.new_frame()
+            if show:
+                imgui.begin("LiveLingo", True, imgui.WINDOW_ALWAYS_AUTO_RESIZE)
+                imgui.text("ImGui UI placeholder")
+                imgui.end()
             imgui.render()
-            impl.render(imgui.get_draw_data())
+            if show:
+                impl.render(imgui.get_draw_data())
             glfw.swap_buffers(window)
     finally:
         impl.shutdown()
-        imgui.destroy_context()   # ★ 깔끔 종료
+        imgui.destroy_context()
         glfw.terminate()


### PR DESCRIPTION
## Summary
- Start the audio client and ImGui overlay together without a `--gui` flag
- Add a transparent, always-on-top ImGui overlay with Insert-key toggling
- Update README usage instructions

## Testing
- `python -m py_compile main.py src/livelingo/cli.py src/livelingo/client.py src/livelingo/ui.py`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689b01284978832aaff461336ff5a514